### PR TITLE
Fix: Allow passing in connection names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typeorm-fixture-builder",
   "description": "Painless and type safe data fixtures for typeorm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "repository": "github:jeanfortheweb/typeorm-fixture-builder",
   "author": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,7 +187,7 @@ program
     'Drops and synchronizes the database before loading fixtures',
   )
   .option(
-    '-c, --connection',
+    '-c, --connection <name>',
     'Name of connection to use. Check the typeorm documentation for further information. [default: "default"]',
     'default',
   )


### PR DESCRIPTION
Looks like you just forgot the `<name>` part from the commanded option on my PR. This should do the trick.
