### PR TITLE
Fix resolver type in fixture.ts

### DIFF
--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -13,7 +13,7 @@ import { Resolver } from './resolve';
 export function fixture<Entity extends new () => any>(
   entity: Entity,
   data: DeepPartial<InstanceType<Entity>>,
-  resolver?: Resolver<Entity>,
+  resolver?: Resolver<InstanceType<Entity>>,
 ): Entity {
   const instance = new entity();
 


### PR DESCRIPTION
After f1f25a60c0498ac12b24382051294478069091ac, my project has type errors when using custom resolvers. This patch fixes the issue for me.